### PR TITLE
Fix for shutdownhook execution failure, for proper shutdown

### DIFF
--- a/src/main/java/com/gotocompany/firehose/sink/blob/writer/WriterOrchestrator.java
+++ b/src/main/java/com/gotocompany/firehose/sink/blob/writer/WriterOrchestrator.java
@@ -125,7 +125,7 @@ public class WriterOrchestrator implements Closeable {
         if (!writer.write(record)) {
             return write(record, timePartitionedPath);
         }
-        return writer.getMetadata().getFullPath();
+        return writer.getFullPath();
     }
 
     @Override

--- a/src/main/java/com/gotocompany/firehose/sink/blob/writer/WriterOrchestrator.java
+++ b/src/main/java/com/gotocompany/firehose/sink/blob/writer/WriterOrchestrator.java
@@ -139,7 +139,7 @@ public class WriterOrchestrator implements Closeable {
             writer.close();
         }
         for (LocalFileWriter p : timePartitionWriterMap.values()) {
-            localStorage.deleteLocalFile(p.getMetadata().getFullPath());
+            localStorage.deleteLocalFile(p.getFullPath());
         }
     }
 }

--- a/src/main/java/com/gotocompany/firehose/sink/blob/writer/local/LocalFileWriter.java
+++ b/src/main/java/com/gotocompany/firehose/sink/blob/writer/local/LocalFileWriter.java
@@ -16,4 +16,6 @@ public interface LocalFileWriter extends Closeable {
     LocalFileMetadata getMetadata();
 
     LocalFileMetadata closeAndFetchMetaData() throws IOException;
+
+    String getFullPath();
 }

--- a/src/main/java/com/gotocompany/firehose/sink/blob/writer/local/LocalParquetFileWriter.java
+++ b/src/main/java/com/gotocompany/firehose/sink/blob/writer/local/LocalParquetFileWriter.java
@@ -71,8 +71,8 @@ public class LocalParquetFileWriter implements LocalFileWriter {
         return metadata;
     }
 
-	@Override
-	public String getFullPath() {
-		return fullPath;
-	}
+    @Override
+    public String getFullPath() {
+        return fullPath;
+    }
 }

--- a/src/main/java/com/gotocompany/firehose/sink/blob/writer/local/LocalParquetFileWriter.java
+++ b/src/main/java/com/gotocompany/firehose/sink/blob/writer/local/LocalParquetFileWriter.java
@@ -70,4 +70,9 @@ public class LocalParquetFileWriter implements LocalFileWriter {
         this.close();
         return metadata;
     }
+
+	@Override
+	public String getFullPath() {
+		return fullPath;
+	}
 }

--- a/src/test/java/com/gotocompany/firehose/sink/blob/writer/WriterOrchestratorTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/blob/writer/WriterOrchestratorTest.java
@@ -70,7 +70,7 @@ public class WriterOrchestratorTest {
         Record record = Mockito.mock(Record.class);
         Mockito.when(record.getTimestamp(timeStampFieldName)).thenReturn(Instant.ofEpochMilli(1L));
         Mockito.when(record.getTopic("")).thenReturn(defaultTopic);
-        Mockito.when(localFileWriter1.getMetadata()).thenReturn(new LocalFileMetadata("/tmp/", "/tmp/test", 0, 0, 0));
+        Mockito.when(localFileWriter1.getFullPath()).thenReturn("/tmp/test");
         Mockito.when(localStorage.createLocalFileWriter(TimePartitionedPathUtils.getTimePartitionedPath(record, sinkConfig))).thenReturn(localFileWriter1);
         Mockito.when(localFileWriter1.write(record)).thenReturn(true);
         try (WriterOrchestrator writerOrchestrator = new WriterOrchestrator(sinkConfig, localStorage, blobStorage, statsDReporter)) {
@@ -86,14 +86,14 @@ public class WriterOrchestratorTest {
         Mockito.when(record1.getTopic("")).thenReturn(defaultTopic);
         Mockito.when(localStorage.createLocalFileWriter(TimePartitionedPathUtils.getTimePartitionedPath(record1, sinkConfig))).thenReturn(localFileWriter1);
         Mockito.when(localFileWriter1.write(record1)).thenReturn(true);
-        Mockito.when(localFileWriter1.getMetadata()).thenReturn(new LocalFileMetadata("/tmp/", "/tmp/test1", 0, 0, 0));
+        Mockito.when(localFileWriter1.getFullPath()).thenReturn("/tmp/test1");
 
         Record record2 = Mockito.mock(Record.class);
         Mockito.when(record2.getTimestamp(timeStampFieldName)).thenReturn(Instant.ofEpochMilli(7200000L));
         Mockito.when(record2.getTopic("")).thenReturn(defaultTopic);
         Mockito.when(localStorage.createLocalFileWriter(TimePartitionedPathUtils.getTimePartitionedPath(record2, sinkConfig))).thenReturn(localFileWriter2);
         Mockito.when(localFileWriter2.write(record2)).thenReturn(true);
-        Mockito.when(localFileWriter2.getMetadata()).thenReturn(new LocalFileMetadata("/tmp/", "/tmp/test2", 0, 0, 0));
+        Mockito.when(localFileWriter2.getFullPath()).thenReturn("/tmp/test2");
 
         try (WriterOrchestrator writerOrchestrator = new WriterOrchestrator(sinkConfig, localStorage, blobStorage, statsDReporter)) {
             Set<String> paths = new HashSet<>();
@@ -134,7 +134,7 @@ public class WriterOrchestratorTest {
         Record record = Mockito.mock(Record.class);
         Mockito.when(record.getTimestamp(timeStampFieldName)).thenReturn(Instant.ofEpochMilli(1L));
         Mockito.when(record.getTopic("")).thenReturn(defaultTopic);
-        Mockito.when(localFileWriter1.getMetadata()).thenReturn(new LocalFileMetadata("/tmp/", "/tmp/test", 0, 0, 0));
+        Mockito.when(localFileWriter1.getFullPath()).thenReturn("/tmp/test");
         Mockito.when(localStorage.createLocalFileWriter(TimePartitionedPathUtils.getTimePartitionedPath(record, sinkConfig))).thenReturn(localFileWriter1);
         Mockito.when(localFileWriter1.write(record)).thenReturn(true);
         try (WriterOrchestrator writerOrchestrator = new WriterOrchestrator(sinkConfig, localStorage, blobStorage, statsDReporter)) {


### PR DESCRIPTION
## Bug Fix to resolve shutdown hook execution failure
In [WriterOrchestrator](https://github.com/goto/firehose/blob/main/src/main/java/com/gotocompany/firehose/sink/blob/writer/WriterOrchestrator.java) close method we are indirectly referencing a closed resource (ParquetWriter), this will block shutdown hook to execute properly, hence application won't restart and blocks the continuous processing.

Since we are using just the filePath from [LocalParquetFileWriter](https://github.com/goto/firehose/blob/main/src/main/java/com/gotocompany/firehose/sink/blob/writer/local/LocalParquetFileWriter.java) for deleting the file , I have added a new get method for the same. This will avoid invoking closed ParquetWriter. Please find attached screen shot for more understanding.

`WriterOrchestrator`
![Screenshot 2023-07-11 at 12 17 33 PM](https://github.com/goto/firehose/assets/20720182/1b4c0259-a45b-4afc-b0a9-bd48e170f0a7)

`LocalParquetFileWriter`
![Screenshot 2023-07-11 at 12 18 48 PM](https://github.com/goto/firehose/assets/20720182/780c7123-7052-4292-a45d-45a125f9e236)

