### PR TITLE
support ability to use json message for http sink

### DIFF
--- a/src/main/java/com/gotocompany/firehose/consumer/kafka/FirehoseKafkaConsumer.java
+++ b/src/main/java/com/gotocompany/firehose/consumer/kafka/FirehoseKafkaConsumer.java
@@ -57,7 +57,9 @@ public class FirehoseKafkaConsumer implements AutoCloseable {
         List<Message> messages = new ArrayList<>();
 
         for (ConsumerRecord<byte[], byte[]> record : records) {
-            messages.add(new Message(record.key(), record.value(), record.topic(), record.partition(), record.offset(), record.headers(), record.timestamp(), System.currentTimeMillis(), this.consumerConfig.getInputSchemaType()));
+            Message msg = new Message(record.key(), record.value(), record.topic(), record.partition(), record.offset(), record.headers(), record.timestamp(), System.currentTimeMillis());
+            msg.setInputSchemaType(consumerConfig.getInputSchemaType());
+            messages.add(msg);
             firehoseInstrumentation.logDebug("Pulled record: {}", record);
         }
 

--- a/src/main/java/com/gotocompany/firehose/consumer/kafka/FirehoseKafkaConsumer.java
+++ b/src/main/java/com/gotocompany/firehose/consumer/kafka/FirehoseKafkaConsumer.java
@@ -57,9 +57,10 @@ public class FirehoseKafkaConsumer implements AutoCloseable {
         List<Message> messages = new ArrayList<>();
 
         for (ConsumerRecord<byte[], byte[]> record : records) {
-            messages.add(new Message(record.key(), record.value(), record.topic(), record.partition(), record.offset(), record.headers(), record.timestamp(), System.currentTimeMillis()));
+            messages.add(new Message(record.key(), record.value(), record.topic(), record.partition(), record.offset(), record.headers(), record.timestamp(), System.currentTimeMillis(), this.consumerConfig.getInputSchemaType()));
             firehoseInstrumentation.logDebug("Pulled record: {}", record);
         }
+
         return messages;
     }
 

--- a/src/main/java/com/gotocompany/firehose/message/Message.java
+++ b/src/main/java/com/gotocompany/firehose/message/Message.java
@@ -30,7 +30,7 @@ public class Message {
     private long consumeTimestamp;
     @Setter
     private ErrorInfo errorInfo;
-
+    @Setter
     private InputSchemaType inputSchemaType;
 
     public void setDefaultErrorIfNotPresent() {
@@ -57,7 +57,7 @@ public class Message {
     }
 
     /**
-     * Instantiates a new Message without providing errorType.
+     * Instantiates a new Message without providing errorType and inputSchemaType.
      *
      * @param logKey
      * @param logMessage
@@ -68,8 +68,8 @@ public class Message {
      * @param timestamp
      * @param consumeTimestamp
      */
-    public Message(byte[] logKey, byte[] logMessage, String topic, int partition, long offset, Headers headers, long timestamp, long consumeTimestamp, InputSchemaType inputSchemaType) {
-        this(logKey, logMessage, topic, partition, offset, headers, timestamp, consumeTimestamp, null, inputSchemaType);
+    public Message(byte[] logKey, byte[] logMessage, String topic, int partition, long offset, Headers headers, long timestamp, long consumeTimestamp) {
+        this(logKey, logMessage, topic, partition, offset, headers, timestamp, consumeTimestamp, null, InputSchemaType.PROTOBUF);
     }
 
     public Message(Message message, ErrorInfo errorInfo) {
@@ -82,7 +82,22 @@ public class Message {
                 message.getTimestamp(),
                 message.getConsumeTimestamp(),
                 errorInfo,
-                message.getInputSchemaType());
+                message.getInputSchemaType()
+        );
+    }
+
+    public Message(Message message, ErrorInfo errorInfo, InputSchemaType inputSchemaType) {
+        this(message.getLogKey(),
+                message.getLogMessage(),
+                message.getTopic(),
+                message.getPartition(),
+                message.getOffset(),
+                message.getHeaders(),
+                message.getTimestamp(),
+                message.getConsumeTimestamp(),
+                errorInfo,
+                inputSchemaType
+        );
     }
 
     /**

--- a/src/main/java/com/gotocompany/firehose/message/Message.java
+++ b/src/main/java/com/gotocompany/firehose/message/Message.java
@@ -1,6 +1,7 @@
 package com.gotocompany.firehose.message;
 
 
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.exception.DefaultException;
 import com.gotocompany.depot.error.ErrorInfo;
 import com.gotocompany.depot.error.ErrorType;
@@ -29,6 +30,8 @@ public class Message {
     private long consumeTimestamp;
     @Setter
     private ErrorInfo errorInfo;
+
+    private InputSchemaType inputSchemaType;
 
     public void setDefaultErrorIfNotPresent() {
         if (errorInfo == null) {
@@ -65,8 +68,8 @@ public class Message {
      * @param timestamp
      * @param consumeTimestamp
      */
-    public Message(byte[] logKey, byte[] logMessage, String topic, int partition, long offset, Headers headers, long timestamp, long consumeTimestamp) {
-        this(logKey, logMessage, topic, partition, offset, headers, timestamp, consumeTimestamp, null);
+    public Message(byte[] logKey, byte[] logMessage, String topic, int partition, long offset, Headers headers, long timestamp, long consumeTimestamp, InputSchemaType inputSchemaType) {
+        this(logKey, logMessage, topic, partition, offset, headers, timestamp, consumeTimestamp, null, inputSchemaType);
     }
 
     public Message(Message message, ErrorInfo errorInfo) {
@@ -78,7 +81,8 @@ public class Message {
                 message.getHeaders(),
                 message.getTimestamp(),
                 message.getConsumeTimestamp(),
-                errorInfo);
+                errorInfo,
+                message.getInputSchemaType());
     }
 
     /**

--- a/src/main/java/com/gotocompany/firehose/serializer/MessageToJson.java
+++ b/src/main/java/com/gotocompany/firehose/serializer/MessageToJson.java
@@ -1,6 +1,7 @@
 package com.gotocompany.firehose.serializer;
 
 
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.message.Message;
 import com.gotocompany.firehose.exception.DeserializerException;
 import com.google.gson.ExclusionStrategy;
@@ -17,6 +18,7 @@ import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,6 +56,13 @@ public class MessageToJson implements MessageSerializer {
         try {
             JSONObject jsonObject = new JSONObject();
             jsonObject.put("topic", message.getTopic());
+
+            if (message.getInputSchemaType() == InputSchemaType.JSON) {
+                JSONParser parser = new JSONParser();
+                JSONObject json = (JSONObject) parser.parse(new String(message.getLogMessage(), StandardCharsets.UTF_8));
+                jsonObject.put("logMessage", json);
+                return jsonObject.toJSONString();
+            }
 
             if (message.getLogKey() != null && message.getLogKey().length != 0) {
                 DynamicMessage key = protoParser.parse(message.getLogKey());

--- a/src/main/java/com/gotocompany/firehose/serializer/MessageToJson.java
+++ b/src/main/java/com/gotocompany/firehose/serializer/MessageToJson.java
@@ -60,7 +60,11 @@ public class MessageToJson implements MessageSerializer {
             if (message.getInputSchemaType() == InputSchemaType.JSON) {
                 JSONParser parser = new JSONParser();
                 JSONObject json = (JSONObject) parser.parse(new String(message.getLogMessage(), StandardCharsets.UTF_8));
-                jsonObject.put("logMessage", json);
+                jsonObject.put("logMessage", gson.toJson(json));
+                if (message.getLogKey() != null && message.getLogKey().length != 0) {
+                    jsonObject.put("logKey", new String(message.getLogKey(), StandardCharsets.UTF_8));
+                }
+
                 return jsonObject.toJSONString();
             }
 

--- a/src/main/java/com/gotocompany/firehose/serializer/MessageToTemplatizedJson.java
+++ b/src/main/java/com/gotocompany/firehose/serializer/MessageToTemplatizedJson.java
@@ -82,8 +82,7 @@ public class MessageToTemplatizedJson implements MessageSerializer {
             String jsonString;
 
             if (message.getInputSchemaType() == InputSchemaType.JSON) {
-                JSONParser parser = new JSONParser();
-                JSONObject json = (JSONObject) parser.parse(new String(message.getLogMessage(), StandardCharsets.UTF_8));
+                JSONObject json = (JSONObject) jsonParser.parse(new String(message.getLogMessage(), StandardCharsets.UTF_8));
                 jsonMessage = json.toJSONString();
             } else {
                 // only supports messages not keys

--- a/src/main/java/com/gotocompany/firehose/serializer/MessageToTemplatizedJson.java
+++ b/src/main/java/com/gotocompany/firehose/serializer/MessageToTemplatizedJson.java
@@ -90,7 +90,6 @@ public class MessageToTemplatizedJson implements MessageSerializer {
                 jsonMessage = JsonFormat.printer().includingDefaultValueFields().preservingProtoFieldNames().print(msg);
             }
 
-
             String finalMessage = httpSinkJsonBodyTemplate;
             for (String path : pathsToReplace) {
                 if (path.equals(ALL_FIELDS_FROM_TEMPLATE)) {

--- a/src/main/java/com/gotocompany/firehose/sink/http/factory/SerializerFactory.java
+++ b/src/main/java/com/gotocompany/firehose/sink/http/factory/SerializerFactory.java
@@ -27,6 +27,11 @@ public class SerializerFactory {
         if (isProtoSchemaEmpty() || httpSinkConfig.getSinkHttpDataFormat() == HttpSinkDataFormatType.PROTO) {
             firehoseInstrumentation.logDebug("Serializer type: JsonWrappedProtoByte");
             // Fallback to json wrapped proto byte
+
+            // todo(sushmith):
+            //  here output is proto, but input expected is also proto.
+            //  need to have json as input and proto as output.
+            //  this is currently not possible because of the way we are using the parser.
             return new JsonWrappedProtoByte();
         }
 

--- a/src/test/java/com/gotocompany/firehose/serializer/MessageToJsonTest.java
+++ b/src/test/java/com/gotocompany/firehose/serializer/MessageToJsonTest.java
@@ -1,5 +1,6 @@
 package com.gotocompany.firehose.serializer;
 
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.exception.DeserializerException;
 import com.gotocompany.firehose.message.Message;
 import com.gotocompany.firehose.consumer.TestAggregatedSupplyMessage;
@@ -9,6 +10,8 @@ import com.gotocompany.stencil.Parser;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import static org.junit.Assert.assertEquals;
@@ -16,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 public class MessageToJsonTest {
     private String logMessage;
     private String logKey;
+    private String logMessageJSONString;
+    private String logKeyJSONString;
     private Parser protoParser;
 
     @Before
@@ -24,6 +29,20 @@ public class MessageToJsonTest {
         protoParser = stencilClient.getParser(TestAggregatedSupplyMessage.class.getName());
         logMessage = "CgYIyOm+xgUSBgiE6r7GBRgNIICAgIDA9/y0LigCMAM\u003d";
         logKey = "CgYIyOm+xgUSBgiE6r7GBRgNIICAgIDA9/y0LigC";
+
+        logMessageJSONString = "{\n" +
+                "    \"uniqueDrivers\": \"3\",\n" +
+                "    \"windowStartTime\": \"Mar 20, 2017 10:54:00 AM\",\n" +
+                "    \"windowEndTime\": \"Mar 20, 2017 10:55:00 AM\",\n" +
+                "    \"s2IdLevel\": 13,\n" +
+                "    \"vehicleType\": \"BIKE\",\n" +
+                "    \"s2Id\": \"3344472187078705152\"\n" +
+                "  }";
+        logKeyJSONString = "sample-key1";
+    }
+
+    public byte[] stringToByteArray(String inputString) {
+        return StandardCharsets.UTF_8.encode(inputString).array();
     }
 
     @Test
@@ -42,6 +61,23 @@ public class MessageToJsonTest {
                 + "\\\"s2Id\\\":\\\"3344472187078705152\\\"}\"}");
     }
 
+
+    @Test
+    public void shouldProperlySerializeJsonInputMessage() throws DeserializerException {
+        MessageToJson messageToJson = new MessageToJson(protoParser, false, true);
+        Message message = new Message(logKeyJSONString.getBytes(), logMessageJSONString.getBytes(), "sample-topic", 0, 100);
+        message.setInputSchemaType(InputSchemaType.JSON);
+
+        String expectedOutput = "{\"logMessage\":\"{\\\"uniqueDrivers\\\":\\\"3\\\"," +
+                "\\\"windowStartTime\\\":\\\"Mar 20, 2017 10:54:00 AM\\\"," +
+                "\\\"windowEndTime\\\":\\\"Mar 20, 2017 10:55:00 AM\\\"," +
+                "\\\"s2IdLevel\\\":13,\\\"vehicleType\\\":\\\"BIKE\\\",\\\"s2Id\\\":\\\"3344472187078705152\\\"}\"," +
+                "\"topic\":\"sample-topic\",\"logKey\":\"sample-key1\"}";
+
+        String actualOutput = messageToJson.serialize(message);
+        assertEquals(expectedOutput, actualOutput);
+    }
+
     @Test
     public void shouldSerializeWhenKeyIsMissing() throws DeserializerException {
         MessageToJson messageToJson = new MessageToJson(protoParser, false, true);
@@ -53,6 +89,21 @@ public class MessageToJsonTest {
                 + "\\\"windowStartTime\\\":\\\"Mar 20, 2017 10:54:00 AM\\\","
                 + "\\\"windowEndTime\\\":\\\"Mar 20, 2017 10:55:00 AM\\\",\\\"s2IdLevel\\\":13,\\\"vehicleType\\\":\\\"BIKE\\\","
                 + "\\\"s2Id\\\":\\\"3344472187078705152\\\"}\",\"topic\":\"sample-topic\"}", actualOutput);
+    }
+
+    @Test
+    public void shouldSerializeJSONInputMessageWhenKeyIsMissing() throws DeserializerException {
+        MessageToJson messageToJson = new MessageToJson(protoParser, false, true);
+        Message message = new Message(null, logMessageJSONString.getBytes(), "sample-topic", 0, 100);
+        message.setInputSchemaType(InputSchemaType.JSON);
+
+        String actualOutput = messageToJson.serialize(message);
+        assertEquals("{\"logMessage\":\"{\\\"uniqueDrivers\\\":\\\"3\\\","
+                + "\\\"windowStartTime\\\":\\\"Mar 20, 2017 10:54:00 AM\\\","
+                + "\\\"windowEndTime\\\":\\\"Mar 20, 2017 10:55:00 AM\\\",\\\"s2IdLevel\\\":13,\\\"vehicleType\\\":\\\"BIKE\\\","
+                + "\\\"s2Id\\\":\\\"3344472187078705152\\\"}\",\"topic\":\"sample-topic\"}", actualOutput);
+
+
     }
 
     @Test
@@ -113,3 +164,5 @@ public class MessageToJsonTest {
                 + "\\\"s2Id\\\":\\\"3344472187078705152\\\"}\",\"topic\":\"sample-topic\"}]", actualOutput);
     }
 }
+
+

--- a/src/test/java/com/gotocompany/firehose/serializer/MessageToTemplatizedJsonTest.java
+++ b/src/test/java/com/gotocompany/firehose/serializer/MessageToTemplatizedJsonTest.java
@@ -1,8 +1,7 @@
 package com.gotocompany.firehose.serializer;
 
 
-
-
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.exception.ConfigurationException;
 import com.gotocompany.firehose.exception.DeserializerException;
 import com.gotocompany.firehose.message.Message;
@@ -41,12 +40,23 @@ public class MessageToTemplatizedJsonTest {
 
     private String logMessage;
     private String logKey;
+    private String logMessageJSONString;
+    private String logKeyJSONString;
 
     @Before
     public void setup() {
         initMocks(this);
         logMessage = "CgYIyOm+xgUSBgiE6r7GBRgNIICAgIDA9/y0LigCMAM\u003d";
         logKey = "CgYIyOm+xgUSBgiE6r7GBRgNIICAgIDA9/y0LigC";
+        logMessageJSONString = "{\n" +
+                "    \"uniqueDrivers\": \"3\",\n" +
+                "    \"windowStartTime\": \"Mar 20, 2017 10:54:00 AM\",\n" +
+                "    \"windowEndTime\": \"Mar 20, 2017 10:55:00 AM\",\n" +
+                "    \"s2IdLevel\": 13,\n" +
+                "    \"vehicleType\": \"BIKE\",\n" +
+                "    \"s2Id\": \"3344472187078705152\"\n" +
+                "  }";
+        logKeyJSONString = "sample-key1";
     }
 
     @Test
@@ -61,6 +71,23 @@ public class MessageToTemplatizedJsonTest {
 
         String serializedMessage = messageToTemplatizedJson.serialize(message);
         String expectedMessage = "{\"test\":\"BIKE\"}";
+        Assert.assertEquals(expectedMessage, serializedMessage);
+    }
+
+    @Test
+    public void shouldProperlySerializeJsonInputMessageToTemplateWithSingleKnownField() throws DeserializerException {
+        String template = "{\"test\":\"$.vehicleType\"}";
+        StencilClient stencilClient = StencilClientFactory.getClient();
+        protoParser = stencilClient.getParser(TestAggregatedSupplyMessage.class.getName());
+        MessageToTemplatizedJson messageToTemplatizedJson = MessageToTemplatizedJson
+                .create(firehoseInstrumentation, template, protoParser);
+        Message message = new Message(logKeyJSONString.getBytes(), logMessageJSONString.getBytes(), "sample-topic", 0, 100);
+        message.setInputSchemaType(InputSchemaType.JSON);
+
+        String expectedMessage = "{\"test\":\"BIKE\"}";
+
+        String serializedMessage = messageToTemplatizedJson.serialize(message);
+
         Assert.assertEquals(expectedMessage, serializedMessage);
     }
 
@@ -87,6 +114,26 @@ public class MessageToTemplatizedJsonTest {
     }
 
     @Test
+    public void shouldProperlySerializeJsonInputMessageToTemplateAsItIs() throws DeserializerException {
+        String template = "\"$._all_\"";
+        StencilClient stencilClient = StencilClientFactory.getClient();
+        protoParser = stencilClient.getParser(TestAggregatedSupplyMessage.class.getName());
+        MessageToTemplatizedJson messageToTemplatizedJson = MessageToTemplatizedJson
+                .create(firehoseInstrumentation, template, protoParser);
+        Message message = new Message(logKeyJSONString.getBytes(), logMessageJSONString.getBytes(), "sample-topic", 0, 100);
+        message.setInputSchemaType(InputSchemaType.JSON);
+
+        String expectedMessage = "{\"uniqueDrivers\":\"3\"," +
+                "\"windowStartTime\":\"Mar 20, 2017 10:54:00 AM\"," +
+                "\"windowEndTime\":\"Mar 20, 2017 10:55:00 AM\",\"s2IdLevel\":13," +
+                "\"vehicleType\":\"BIKE\",\"s2Id\":\"3344472187078705152\"}";
+
+        String serializedMessage = messageToTemplatizedJson.serialize(message);
+
+        Assert.assertEquals(expectedMessage, serializedMessage);
+    }
+
+    @Test
     public void shouldThrowIfNoPathsFoundInTheProto() {
         expectedException.expect(DeserializerException.class);
         expectedException.expectMessage("No results for path: $['invalidPath']");
@@ -98,6 +145,22 @@ public class MessageToTemplatizedJsonTest {
                 .create(firehoseInstrumentation, template, protoParser);
         Message message = new Message(Base64.getDecoder().decode(logKey.getBytes()),
                 Base64.getDecoder().decode(logMessage.getBytes()), "sample-topic", 0, 100);
+
+        messageToTemplatizedJson.serialize(message);
+    }
+
+    @Test
+    public void shouldThrowIfNoPathsFoundInTheJSON() {
+        expectedException.expect(DeserializerException.class);
+        expectedException.expectMessage("No results for path: $['invalidPath']");
+
+        String template = "{\"test\":\"$.invalidPath\"}";
+        StencilClient stencilClient = StencilClientFactory.getClient();
+        protoParser = stencilClient.getParser(TestAggregatedSupplyMessage.class.getName());
+        MessageToTemplatizedJson messageToTemplatizedJson = MessageToTemplatizedJson
+                .create(firehoseInstrumentation, template, protoParser);
+        Message message = new Message(logKeyJSONString.getBytes(), logMessageJSONString.getBytes(), "sample-topic", 0, 100);
+        message.setInputSchemaType(InputSchemaType.JSON);
 
         messageToTemplatizedJson.serialize(message);
     }

--- a/src/test/java/com/gotocompany/firehose/sink/dlq/LogDlqWriterTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/dlq/LogDlqWriterTest.java
@@ -2,6 +2,7 @@ package com.gotocompany.firehose.sink.dlq;
 
 import com.gotocompany.depot.error.ErrorInfo;
 import com.gotocompany.depot.error.ErrorType;
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.message.Message;
 import com.gotocompany.firehose.metrics.FirehoseInstrumentation;
 import com.gotocompany.firehose.sink.dlq.log.LogDlqWriter;
@@ -35,7 +36,7 @@ public class LogDlqWriterTest {
     @Test
     public void shouldWriteMessagesToLog() throws IOException {
         long timestamp = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR));
+        Message message = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         String key = new String(message.getLogKey());
         String value = new String(message.getLogMessage());
@@ -51,7 +52,7 @@ public class LogDlqWriterTest {
     @Test
     public void shouldWriteMessagesToLogWhenKeyIsNull() throws IOException {
         long timestamp = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message = new Message(null, "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR));
+        Message message = new Message(null, "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         String value = new String(message.getLogMessage());
         ErrorInfo errorInfo = message.getErrorInfo();
@@ -66,7 +67,7 @@ public class LogDlqWriterTest {
     @Test
     public void shouldWriteMessagesToLogWhenValueIsNull() throws IOException {
         long timestamp = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message = new Message("123".getBytes(), null, "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR));
+        Message message = new Message("123".getBytes(), null, "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         String key = new String(message.getLogKey());
         ErrorInfo errorInfo = message.getErrorInfo();
@@ -81,7 +82,7 @@ public class LogDlqWriterTest {
     @Test
     public void shouldWriteMessagesToLogWhenErrorInfoIsNull() throws IOException {
         long timestamp = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, null);
+        Message message = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, null, InputSchemaType.PROTOBUF);
 
         String key = new String(message.getLogKey());
         String value = new String(message.getLogMessage());
@@ -95,7 +96,7 @@ public class LogDlqWriterTest {
     @Test
     public void shouldWriteMessagesToLogWhenErrorInfoExceptionIsNull() throws IOException {
         long timestamp = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(null, ErrorType.DESERIALIZATION_ERROR));
+        Message message = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp, timestamp, new ErrorInfo(null, ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         String key = new String(message.getLogKey());
         String value = new String(message.getLogMessage());

--- a/src/test/java/com/gotocompany/firehose/sink/dlq/blobstorage/BlobStorageDlqWriterTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/dlq/blobstorage/BlobStorageDlqWriterTest.java
@@ -2,6 +2,7 @@ package com.gotocompany.firehose.sink.dlq.blobstorage;
 
 import com.gotocompany.depot.error.ErrorInfo;
 import com.gotocompany.depot.error.ErrorType;
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.exception.DeserializerException;
 import com.gotocompany.firehose.message.Message;
 import com.gotocompany.firehose.sink.common.blobstorage.BlobStorage;
@@ -37,12 +38,12 @@ public class BlobStorageDlqWriterTest {
     @Test
     public void shouldWriteMessagesWithoutErrorInfoToObjectStorage() throws IOException, BlobStorageException {
         long timestamp1 = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp1, timestamp1, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR));
-        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, timestamp1, timestamp1, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR));
+        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp1, timestamp1, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, timestamp1, timestamp1, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         long timestamp2 = Instant.parse("2020-01-02T00:00:00Z").toEpochMilli();
-        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, timestamp2, timestamp2, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR));
-        Message message4 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 4, null, timestamp2, timestamp2, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR));
+        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, timestamp2, timestamp2, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message4 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 4, null, timestamp2, timestamp2, new ErrorInfo(new IOException("test"), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         List<Message> messages = Arrays.asList(message1, message2, message3, message4);
         Assert.assertEquals(0, blobStorageDLQWriter.write(messages).size());
@@ -58,12 +59,12 @@ public class BlobStorageDlqWriterTest {
     @Test
     public void shouldWriteMessageErrorTypesToObjectStorage() throws IOException, BlobStorageException {
         long timestamp1 = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp1, timestamp1, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR));
-        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, timestamp1, timestamp1, new ErrorInfo(new NullPointerException(), ErrorType.SINK_UNKNOWN_ERROR));
+        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp1, timestamp1, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, timestamp1, timestamp1, new ErrorInfo(new NullPointerException(), ErrorType.SINK_UNKNOWN_ERROR), InputSchemaType.PROTOBUF);
 
         long timestamp2 = Instant.parse("2020-01-02T00:00:00Z").toEpochMilli();
-        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR));
-        Message message4 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 4, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.SINK_UNKNOWN_ERROR));
+        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message4 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 4, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.SINK_UNKNOWN_ERROR), InputSchemaType.PROTOBUF);
 
         List<Message> messages = Arrays.asList(message1, message2, message3, message4);
         Assert.assertEquals(0, blobStorageDLQWriter.write(messages).size());
@@ -79,12 +80,12 @@ public class BlobStorageDlqWriterTest {
     @Test
     public void shouldThrowIOExceptionWhenWriteFileThrowIOException() throws IOException, BlobStorageException {
         long timestamp1 = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp1, timestamp1, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR));
-        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, timestamp1, timestamp1, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR));
+        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, timestamp1, timestamp1, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, timestamp1, timestamp1, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         long timestamp2 = Instant.parse("2020-01-02T00:00:00Z").toEpochMilli();
-        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR));
-        Message message4 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 4, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR));
+        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message4 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 4, null, timestamp2, timestamp2, new ErrorInfo(new DeserializerException(""), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         doThrow(new BlobStorageException("", "", new IOException())).when(blobStorage).store(anyString(), any(byte[].class));
 

--- a/src/test/java/com/gotocompany/firehose/sinkdecorator/SinkWithDlqTest.java
+++ b/src/test/java/com/gotocompany/firehose/sinkdecorator/SinkWithDlqTest.java
@@ -2,6 +2,7 @@ package com.gotocompany.firehose.sinkdecorator;
 
 import com.gotocompany.firehose.config.DlqConfig;
 import com.gotocompany.firehose.config.ErrorConfig;
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.error.ErrorHandler;
 import com.gotocompany.firehose.message.Message;
 import com.gotocompany.firehose.metrics.FirehoseInstrumentation;
@@ -180,9 +181,9 @@ public class SinkWithDlqTest {
     @Test
     public void shouldCommitOffsetsOfDlqMessagesWhenSinkManageOffset() throws IOException {
         long timestamp = Instant.parse("2020-01-01T00:00:00Z").toEpochMilli();
-        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, 0, timestamp, new ErrorInfo(new IOException(), ErrorType.DESERIALIZATION_ERROR));
-        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, 0, timestamp, new ErrorInfo(new IOException(), ErrorType.DESERIALIZATION_ERROR));
-        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, 0, timestamp, new ErrorInfo(new IOException(), ErrorType.DESERIALIZATION_ERROR));
+        Message message1 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 1, null, 0, timestamp, new ErrorInfo(new IOException(), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message2 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 2, null, 0, timestamp, new ErrorInfo(new IOException(), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
+        Message message3 = new Message("123".getBytes(), "abc".getBytes(), "booking", 1, 3, null, 0, timestamp, new ErrorInfo(new IOException(), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF);
 
         ArrayList<Message> messages = new ArrayList<>();
         messages.add(message1);

--- a/src/test/java/com/gotocompany/firehose/sinkdecorator/SinkWithFailHandlerTest.java
+++ b/src/test/java/com/gotocompany/firehose/sinkdecorator/SinkWithFailHandlerTest.java
@@ -1,6 +1,7 @@
 package com.gotocompany.firehose.sinkdecorator;
 
 import com.gotocompany.firehose.config.ErrorConfig;
+import com.gotocompany.firehose.config.enums.InputSchemaType;
 import com.gotocompany.firehose.error.ErrorHandler;
 import com.gotocompany.firehose.exception.SinkException;
 import com.gotocompany.firehose.message.Message;
@@ -37,7 +38,7 @@ public class SinkWithFailHandlerTest {
         List<Message> messages = new LinkedList<>();
         messages.add(new Message("".getBytes(), "".getBytes(), "basic", 1, 1,
                 null, 0, 0,
-                new ErrorInfo(new RuntimeException(), ErrorType.DESERIALIZATION_ERROR)));
+                new ErrorInfo(new RuntimeException(), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF));
 
         when(sink.pushMessage(anyList())).thenReturn(messages);
 
@@ -54,7 +55,7 @@ public class SinkWithFailHandlerTest {
         List<Message> messages = new LinkedList<>();
         messages.add(new Message("".getBytes(), "".getBytes(), "basic", 1, 1,
                 null, 0, 0,
-                new ErrorInfo(new RuntimeException(), ErrorType.DESERIALIZATION_ERROR)));
+                new ErrorInfo(new RuntimeException(), ErrorType.DESERIALIZATION_ERROR), InputSchemaType.PROTOBUF));
 
         when(sink.pushMessage(anyList())).thenReturn(messages);
 

--- a/src/test/java/com/gotocompany/firehose/sinkdecorator/SinkWithRetryTest.java
+++ b/src/test/java/com/gotocompany/firehose/sinkdecorator/SinkWithRetryTest.java
@@ -231,11 +231,13 @@ public class SinkWithRetryTest {
 
     @Test
     public void shouldRetryMessagesWhenErrorTypesConfigured() throws IOException {
-        Message messageWithError = new Message("key".getBytes(), "value".getBytes(), "topic", 1, 1, null, 0, 0, new ErrorInfo(null, ErrorType.DESERIALIZATION_ERROR));
+        InputSchemaType inputSchemaType = InputSchemaType.PROTOBUF;
+        ErrorInfo errorInfo = new ErrorInfo(null, ErrorType.DESERIALIZATION_ERROR);
+        Message messageWithError = new Message("key".getBytes(), "value".getBytes(), "topic", 1, 1, null, 0, 0, errorInfo, inputSchemaType);
 
         ArrayList<Message> messages = new ArrayList<>();
         messages.add(messageWithError);
-        messages.add(new Message(message, new ErrorInfo(null, ErrorType.SINK_UNKNOWN_ERROR)));
+        messages.add(new Message(message, new ErrorInfo(null, ErrorType.SINK_UNKNOWN_ERROR), inputSchemaType));
         when(sinkDecorator.pushMessage(anyList())).thenReturn(messages).thenReturn(new LinkedList<>());
 
         HashSet<ErrorType> errorTypes = new HashSet<>();


### PR DESCRIPTION
Currently, http sink supports only having proto messages in kafka topic. These changes also support having a topic with only json messages when using a http sink.

**Reasoning behind the changes in the PR:**
Firehose currently tightly couples the source message format and the output sink format. As part of our analysis to add support for the use case of being able to read json message from kafka and send to http sink, we realized that adding the `InputSchemType` to `Message` object would be a simpler way to solve this, without having to change the existing code too much and at the same time without muddling it up.
