### PR TITLE
chore: support keepalive and deadline configuration for grpc sink

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ lombok {
 }
 
 group 'com.gotocompany'
-version '0.9.6'
+version '0.9.7'
 
 def projName = "firehose"
 

--- a/docs/docs/sinks/grpc-sink.md
+++ b/docs/docs/sinks/grpc-sink.md
@@ -31,3 +31,28 @@ Defines the Proto which would be the response of the GRPC Method.
 
 - Example value: `com.tests.SampleGrpcResponse`
 - Type: `required`
+
+### `SINK_GRPC_ARG_KEEPALIVE_TIME_MS`
+
+The keepalive ping is a way to check if a channel is currently working by sending HTTP2 pings over the transport. It is sent periodically, and if the ping is not acknowledged by the peer within a certain timeout period, the transport is disconnected. Other keepalive configurations are described [here](https://github.com/grpc/grpc/blob/master/doc/keepalive.md).
+
+Defines the period (in milliseconds) after which a keepalive ping is sent on the transport. If smaller than 10000, 10000 will be used instead.
+
+- Example value: `60000`
+- Type: `optional`
+- Default value: `infinite`
+
+### `SINK_GRPC_ARG_KEEPALIVE_TIMEOUT_MS`
+
+Defines the amount of time (in milliseconds) the sender of the keepalive ping waits for an acknowledgement. If it does not receive an acknowledgment within this time, it will close the connection.
+
+- Example value: `5000`
+- Type: `optional`
+- Default value: `20000`
+
+### `SINK_GRPC_ARG_DEADLINE_MS`
+
+Defines the amount of time (in milliseconds) gRPC clients are willing to wait for an RPC to complete before the RPC is terminated with the error [DEADLINE_EXCEEDED](https://grpc.io/docs/guides/deadlines/#:~:text=By%20default%2C%20gRPC%20does%20not,realistic%20deadline%20in%20your%20clients.)
+
+- Example value: `1000`
+- Type: `optional`

--- a/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
+++ b/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
@@ -18,14 +18,11 @@ public interface GrpcSinkConfig extends AppConfig {
     String getSinkGrpcResponseSchemaProtoClass();
 
     @Config.Key("SINK_GRPC_ARG_KEEPALIVE_TIME_MS")
-    @Config.DefaultValue("-1")
     Integer getSinkGrpcArgKeepaliveTimeMS();
 
     @Config.Key("SINK_GRPC_ARG_KEEPALIVE_TIMEOUT_MS")
-    @Config.DefaultValue("-1")
     Integer getSinkGrpcArgKeepaliveTimeoutMS();
 
     @Config.Key("SINK_GRPC_ARG_DEADLINE_MS")
-    @Config.DefaultValue("-1")
     Integer getSinkGrpcArgDeadlineMS();
 }

--- a/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
+++ b/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
@@ -18,11 +18,13 @@ public interface GrpcSinkConfig extends AppConfig {
     String getSinkGrpcResponseSchemaProtoClass();
 
     @Config.Key("SINK_GRPC_ARG_KEEPALIVE_TIME_MS")
-    Integer getSinkGrpcArgKeepaliveTimeMS();
+    @Config.DefaultValue("9223372036854775807")
+    Long getSinkGrpcArgKeepaliveTimeMS();
 
     @Config.Key("SINK_GRPC_ARG_KEEPALIVE_TIMEOUT_MS")
-    Integer getSinkGrpcArgKeepaliveTimeoutMS();
+    @DefaultValue("20000")
+    Long getSinkGrpcArgKeepaliveTimeoutMS();
 
     @Config.Key("SINK_GRPC_ARG_DEADLINE_MS")
-    Integer getSinkGrpcArgDeadlineMS();
+    Long getSinkGrpcArgDeadlineMS();
 }

--- a/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
+++ b/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
@@ -17,4 +17,15 @@ public interface GrpcSinkConfig extends AppConfig {
     @Config.Key("SINK_GRPC_RESPONSE_SCHEMA_PROTO_CLASS")
     String getSinkGrpcResponseSchemaProtoClass();
 
+    @Config.Key("SINK_GRPC_ARG_KEEPALIVE_TIME_MS")
+    @Config.DefaultValue("-1")
+    Integer getSinkGrpcArgKeepaliveTimeMS();
+
+    @Config.Key("SINK_GRPC_ARG_KEEPALIVE_TIMEOUT_MS")
+    @Config.DefaultValue("-1")
+    Integer getSinkGrpcArgKeepaliveTimeoutMS();
+
+    @Config.Key("SINK_GRPC_ARG_DEADLINE_MS")
+    @Config.DefaultValue("-1")
+    Integer getSinkGrpcArgDeadlineMS();
 }

--- a/src/main/java/com/gotocompany/firehose/metrics/Metrics.java
+++ b/src/main/java/com/gotocompany/firehose/metrics/Metrics.java
@@ -11,6 +11,7 @@ public class Metrics {
     //SINK PREFIXES
     public static final String SINK_PREFIX = "sink_";
     public static final String HTTP_SINK_PREFIX = "http_";
+    public static final String GRPC_SINK_PREFIX = "grpc_";
     public static final String BLOB_SINK_PREFIX = "blob_";
 
     public static final String MONGO_SINK_PREFIX = "mongo_";
@@ -43,6 +44,7 @@ public class Metrics {
     public static final String SINK_MESSAGES_DROP_TOTAL = APPLICATION_PREFIX + SINK_PREFIX + "messages_drop_total";
     public static final String SINK_HTTP_RESPONSE_CODE_TOTAL = APPLICATION_PREFIX + SINK_PREFIX + HTTP_SINK_PREFIX + "response_code_total";
     public static final String SINK_PUSH_BATCH_SIZE_TOTAL = APPLICATION_PREFIX + SINK_PREFIX + "push_batch_size_total";
+    public static final String SINK_GRPC_ERROR_TOTAL = APPLICATION_PREFIX + GRPC_SINK_PREFIX + "error_total";
 
     // MONGO SINK MEASUREMENTS
     public static final String SINK_MONGO_INSERTED_TOTAL = APPLICATION_PREFIX + SINK_PREFIX + MONGO_SINK_PREFIX + "inserted_total";

--- a/src/main/java/com/gotocompany/firehose/sink/grpc/GrpcSinkFactory.java
+++ b/src/main/java/com/gotocompany/firehose/sink/grpc/GrpcSinkFactory.java
@@ -12,6 +12,7 @@ import com.gotocompany.stencil.client.StencilClient;
 import org.aeonbits.owner.ConfigFactory;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Factory class to create the GrpcSink.
@@ -29,12 +30,25 @@ public class GrpcSinkFactory {
                 grpcConfig.getSinkGrpcServiceHost(), grpcConfig.getSinkGrpcServicePort(), grpcConfig.getSinkGrpcMethodUrl(), grpcConfig.getSinkGrpcResponseSchemaProtoClass());
         firehoseInstrumentation.logDebug(grpcSinkConfig);
 
-        ManagedChannel managedChannel = ManagedChannelBuilder.forAddress(grpcConfig.getSinkGrpcServiceHost(), grpcConfig.getSinkGrpcServicePort()).usePlaintext().build();
+        ManagedChannelBuilder<?> managedChannelBuilder = ManagedChannelBuilder.forAddress(grpcConfig.getSinkGrpcServiceHost(), grpcConfig.getSinkGrpcServicePort())
+                .usePlaintext();
+        ManagedChannel managedChannel = decorateManagedChannelBuilder(grpcConfig, managedChannelBuilder).build();
 
         GrpcClient grpcClient = new GrpcClient(new FirehoseInstrumentation(statsDReporter, GrpcClient.class), grpcConfig, managedChannel, stencilClient);
+        grpcClient.initialize();
         firehoseInstrumentation.logInfo("GRPC connection established");
 
         return new GrpcSink(new FirehoseInstrumentation(statsDReporter, GrpcSink.class), grpcClient, stencilClient);
+    }
+
+    protected static ManagedChannelBuilder<?> decorateManagedChannelBuilder(GrpcSinkConfig grpcConfig, ManagedChannelBuilder<?> channelBuilder) {
+        if (grpcConfig.getSinkGrpcArgKeepaliveTimeMS() != null && grpcConfig.getSinkGrpcArgKeepaliveTimeMS() > 0) {
+            channelBuilder = channelBuilder.keepAliveTime(grpcConfig.getSinkGrpcArgKeepaliveTimeMS(), TimeUnit.MILLISECONDS);
+        }
+        if (grpcConfig.getSinkGrpcArgKeepaliveTimeoutMS() != null && grpcConfig.getSinkGrpcArgKeepaliveTimeoutMS() > 0) {
+            channelBuilder = channelBuilder.keepAliveTimeout(grpcConfig.getSinkGrpcArgKeepaliveTimeoutMS(), TimeUnit.MILLISECONDS);
+        }
+        return channelBuilder;
     }
 
 }

--- a/src/test/java/com/gotocompany/firehose/sink/grpc/GrpcSinkFactoryTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/grpc/GrpcSinkFactoryTest.java
@@ -17,10 +17,9 @@ import org.mockito.Mock;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class GrpcSinkFactoryTest {
@@ -68,41 +67,7 @@ public class GrpcSinkFactoryTest {
         Sink sink = GrpcSinkFactory.create(config, statsDReporter, stencilClient);
 
         Assert.assertNotNull(sink);
+
         server.shutdownNow();
-    }
-
-    @Test
-    public void channelBuilderShouldBeDecoratedWithKeepaliveAndTimeOutMS() {
-        when(grpcConfig.getSinkGrpcArgKeepaliveTimeMS()).thenReturn(1000);
-        when(grpcConfig.getSinkGrpcArgKeepaliveTimeoutMS()).thenReturn(100);
-        when(channelBuilder.keepAliveTime(Integer.parseInt("1000"), TimeUnit.MILLISECONDS)).thenReturn(channelBuilder);
-
-        GrpcSinkFactory.decorateManagedChannelBuilder(grpcConfig, channelBuilder);
-
-        verify(channelBuilder, times(1)).keepAliveTimeout(Integer.parseInt("100"), TimeUnit.MILLISECONDS);
-        verify(channelBuilder, times(1)).keepAliveTime(Integer.parseInt("1000"), TimeUnit.MILLISECONDS);
-    }
-
-    @Test
-    public void channelBuilderShouldBeDecoratedWithOnlyKeepaliveMS() {
-        when(grpcConfig.getSinkGrpcArgKeepaliveTimeMS()).thenReturn(1000);
-        when(grpcConfig.getSinkGrpcArgKeepaliveTimeoutMS()).thenReturn(-1);
-        when(channelBuilder.keepAliveTime(anyInt(), eq(TimeUnit.MILLISECONDS))).thenReturn(channelBuilder);
-
-        GrpcSinkFactory.decorateManagedChannelBuilder(grpcConfig, channelBuilder);
-
-        verify(channelBuilder, times(0)).keepAliveTimeout(anyInt(), eq(TimeUnit.MILLISECONDS));
-        verify(channelBuilder, times(1)).keepAliveTime(Integer.parseInt("1000"), TimeUnit.MILLISECONDS);
-    }
-
-    @Test
-    public void channelBuilderShouldNotBeDecoratedWithKeepaliveAndTimeoutMS() {
-        when(grpcConfig.getSinkGrpcArgKeepaliveTimeMS()).thenReturn(-1);
-        when(grpcConfig.getSinkGrpcArgKeepaliveTimeoutMS()).thenReturn(-1);
-        //when(channelBuilder.keepAliveTime(anyInt(), eq(TimeUnit.MILLISECONDS))).thenReturn(channelBuilder);
-
-        GrpcSinkFactory.decorateManagedChannelBuilder(grpcConfig, channelBuilder);
-        verify(channelBuilder, times(0)).keepAliveTimeout(anyInt(), eq(TimeUnit.MILLISECONDS));
-        verify(channelBuilder, times(0)).keepAliveTime(anyInt(), eq(TimeUnit.MILLISECONDS));
     }
 }

--- a/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
@@ -1,8 +1,8 @@
-package com.gotocompany.firehose.sink.grpc;
+package com.gotocompany.firehose.sink.grpc.client;
+
 
 import com.gotocompany.firehose.config.GrpcSinkConfig;
 import com.gotocompany.firehose.metrics.FirehoseInstrumentation;
-import com.gotocompany.firehose.sink.grpc.client.GrpcClient;
 import com.gotocompany.firehose.consumer.Error;
 import com.gotocompany.firehose.consumer.TestGrpcRequest;
 import com.gotocompany.firehose.consumer.TestGrpcResponse;
@@ -19,6 +19,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Stubber;
 
@@ -32,6 +33,8 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.*;
 
 public class GrpcClientTest {
@@ -43,9 +46,12 @@ public class GrpcClientTest {
     private static final List<String> HEADER_KEYS = Arrays.asList("test-header-key-1", "test-header-key-2");
     private HeaderTestInterceptor headerTestInterceptor;
 
+    @Mock
+    private FirehoseInstrumentation firehoseInstrumentation;
+
     @Before
     public void setup() throws IOException {
-        FirehoseInstrumentation firehoseInstrumentation = Mockito.mock(FirehoseInstrumentation.class);
+        firehoseInstrumentation = Mockito.mock(FirehoseInstrumentation.class);
         testGrpcService = Mockito.mock(TestServerGrpc.TestServerImplBase.class, CALLS_REAL_METHODS);
         headerTestInterceptor = new HeaderTestInterceptor();
         headerTestInterceptor.setHeaderKeys(HEADER_KEYS);
@@ -64,6 +70,7 @@ public class GrpcClientTest {
         StencilClient stencilClient = StencilClientFactory.getClient();
         ManagedChannel managedChannel = ManagedChannelBuilder.forAddress(grpcSinkConfig.getSinkGrpcServiceHost(), grpcSinkConfig.getSinkGrpcServicePort()).usePlaintext().build();
         grpcClient = new GrpcClient(firehoseInstrumentation, grpcSinkConfig, managedChannel, stencilClient);
+        grpcClient.initialize();
         headers = new RecordHeaders();
     }
 
@@ -111,7 +118,6 @@ public class GrpcClientTest {
                 .setField2("field2")
                 .build();
         DynamicMessage response = grpcClient.execute(request.toByteArray(), headers);
-        System.out.println(response.toString());
         assertTrue(Boolean.parseBoolean(String.valueOf(response.getField(TestGrpcResponse.getDescriptor().findFieldByName("success")))));
     }
 
@@ -156,6 +162,29 @@ public class GrpcClientTest {
     }
 
     @Test
+    public void shouldNotDecorateCallOptionsWithDeadline() {
+        CallOptions decorateCallOptions = grpcClient.decorateCallOptions(CallOptions.DEFAULT);
+        assertNull(decorateCallOptions.getDeadline());
+    }
+
+    @Test
+    public void shouldDecorateCallOptionsWithDeadline() {
+        Map<String, String> config = new HashMap<>();
+        config.put("SINK_GRPC_SERVICE_HOST", "localhost");
+        config.put("SINK_GRPC_SERVICE_PORT", "5000");
+        config.put("SINK_GRPC_METHOD_URL", "com.gotocompany.firehose.consumer.TestServer/TestRpcMethod");
+        config.put("SINK_GRPC_RESPONSE_SCHEMA_PROTO_CLASS", "com.gotocompany.firehose.consumer.TestGrpcResponse");
+        config.put("SINK_GRPC_ARG_DEADLINE_MS", "1000");
+        GrpcSinkConfig grpcSinkConfig = ConfigFactory.create(GrpcSinkConfig.class, config);
+        StencilClient stencilClient = StencilClientFactory.getClient();
+        ManagedChannel managedChannel = ManagedChannelBuilder.forAddress(grpcSinkConfig.getSinkGrpcServiceHost(), grpcSinkConfig.getSinkGrpcServicePort()).usePlaintext().build();
+        grpcClient = new GrpcClient(firehoseInstrumentation, grpcSinkConfig, managedChannel, stencilClient);
+
+        CallOptions decorateCallOptions = grpcClient.decorateCallOptions(CallOptions.DEFAULT);
+        assertNotNull(decorateCallOptions.getDeadline());
+    }
+
+    @Test
     public void shouldReturnErrorWhenGrpcException() {
         doThrow(new RuntimeException("error")).when(testGrpcService).testRpcMethod(any(TestGrpcRequest.class), any());
         TestGrpcRequest request = TestGrpcRequest.newBuilder()
@@ -166,6 +195,16 @@ public class GrpcClientTest {
         assertFalse(Boolean.parseBoolean(String.valueOf(response.getField(response.getDescriptorForType().findFieldByName("success")))));
     }
 
+    @Test
+    public void shouldReportMetricsWhenGrpcException() {
+        doThrow(new StatusRuntimeException(Status.UNKNOWN)).when(testGrpcService).testRpcMethod(any(TestGrpcRequest.class), any());
+        TestGrpcRequest request = TestGrpcRequest.newBuilder()
+                .setField1("field1")
+                .setField2("field2")
+                .build();
+       grpcClient.execute(request.toByteArray(), headers);
+       verify(firehoseInstrumentation, times(1)).incrementCounter("firehose_grpc_error_total", "status=" + Status.UNKNOWN.getCode());
+    }
 
     private <T extends AbstractMessage> Stubber doAnswerProtoReponse(T response) {
         return doAnswer(invocation -> {

--- a/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
@@ -30,11 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class GrpcClientTest {
@@ -70,7 +66,6 @@ public class GrpcClientTest {
         StencilClient stencilClient = StencilClientFactory.getClient();
         ManagedChannel managedChannel = ManagedChannelBuilder.forAddress(grpcSinkConfig.getSinkGrpcServiceHost(), grpcSinkConfig.getSinkGrpcServicePort()).usePlaintext().build();
         grpcClient = new GrpcClient(firehoseInstrumentation, grpcSinkConfig, managedChannel, stencilClient);
-        grpcClient.initialize();
         headers = new RecordHeaders();
     }
 
@@ -163,8 +158,8 @@ public class GrpcClientTest {
 
     @Test
     public void shouldNotDecorateCallOptionsWithDeadline() {
-        CallOptions decorateCallOptions = grpcClient.decorateCallOptions(CallOptions.DEFAULT);
-        assertNull(decorateCallOptions.getDeadline());
+        CallOptions decoratedCallOptions = grpcClient.decoratedDefaultCallOptions();
+        assertNull(decoratedCallOptions.getDeadline());
     }
 
     @Test
@@ -180,8 +175,8 @@ public class GrpcClientTest {
         ManagedChannel managedChannel = ManagedChannelBuilder.forAddress(grpcSinkConfig.getSinkGrpcServiceHost(), grpcSinkConfig.getSinkGrpcServicePort()).usePlaintext().build();
         grpcClient = new GrpcClient(firehoseInstrumentation, grpcSinkConfig, managedChannel, stencilClient);
 
-        CallOptions decorateCallOptions = grpcClient.decorateCallOptions(CallOptions.DEFAULT);
-        assertNotNull(decorateCallOptions.getDeadline());
+        CallOptions decoratedCallOptions = grpcClient.decoratedDefaultCallOptions();
+        assertNotNull(decoratedCallOptions.getDeadline());
     }
 
     @Test


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Adding capabilities to set **deadlines**, **keepalive_time**, and **keepalive_timeout** for grpc sink. 

**keepalive_time** and **keepalive_timeout** helps early identify half-open connection.
Linux by default has a mechanism to detect less-clean failure (half-open connection) with net.ipv4.tcp_retries2. This has a default value of 15. Only when that number is reached, the OS will forcefully terminate the “half-open” connection and force the connection to be recreated.

**Deadlines** allow gRPC clients to specify how long they are willing to wait for an RPC to complete before the RPC is terminated with the error DEADLINE_EXCEEDED. If you don’t set a deadline, resources will be held for all in-flight requests, and all requests can potentially reach the maximum timeout. Which would increase the latency of the service. 


