### PR TITLE
fix: allow static metadata in grpc call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ lombok {
 }
 
 group 'com.gotocompany'
-version '0.9.7'
+version '0.9.9'
 
 def projName = "firehose"
 

--- a/docs/docs/sinks/grpc-sink.md
+++ b/docs/docs/sinks/grpc-sink.md
@@ -25,6 +25,15 @@ Defines the URL of the GRPC method that needs to be called.
 - Example value: `com.tests.SampleServer/SomeMethod`
 - Type: `required`
 
+### `SINK_GRPC_METADATA`
+
+Defines the GRPC additional static Metadata that allows clients to provide information to server that is associated with an RPC.
+
+Note - final metadata will be generated with merging static metadata and the kafka record header. 
+
+- Example value: `authorization:token,dlq:true`
+- Type: `optional`
+
 ### `SINK_GRPC_RESPONSE_SCHEMA_PROTO_CLASS`
 
 Defines the Proto which would be the response of the GRPC Method.

--- a/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
+++ b/src/main/java/com/gotocompany/firehose/config/GrpcSinkConfig.java
@@ -1,5 +1,7 @@
 package com.gotocompany.firehose.config;
 
+import com.gotocompany.firehose.config.converter.GrpcMetadataConverter;
+import io.grpc.Metadata;
 import org.aeonbits.owner.Config;
 
 
@@ -27,4 +29,9 @@ public interface GrpcSinkConfig extends AppConfig {
 
     @Config.Key("SINK_GRPC_ARG_DEADLINE_MS")
     Long getSinkGrpcArgDeadlineMS();
+
+    @Key("SINK_GRPC_METADATA")
+    @DefaultValue("")
+    @ConverterClass(GrpcMetadataConverter.class)
+    Metadata getSinkGrpcMetadata();
 }

--- a/src/main/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverter.java
+++ b/src/main/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverter.java
@@ -1,0 +1,23 @@
+package com.gotocompany.firehose.config.converter;
+
+import org.aeonbits.owner.Converter;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import io.grpc.Metadata;
+
+public class GrpcMetadataConverter implements Converter<Metadata> {
+
+    @Override
+    public Metadata convert(Method method, String input) {
+
+        Metadata metadata = new Metadata();
+
+        Arrays.stream(input.split(",")).filter(metadataKeyValue -> !metadataKeyValue.trim().isEmpty()).forEach(metadataKeyValue -> {
+            if (metadataKeyValue.contains(":")) {
+                metadata.put(Metadata.Key.of(metadataKeyValue.split(":")[0], Metadata.ASCII_STRING_MARSHALLER), metadataKeyValue.split(":")[1]);
+            }
+        });
+        return metadata;
+    }
+}

--- a/src/main/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverter.java
+++ b/src/main/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverter.java
@@ -10,14 +10,17 @@ public class GrpcMetadataConverter implements Converter<Metadata> {
 
     @Override
     public Metadata convert(Method method, String input) {
-
         Metadata metadata = new Metadata();
+        Arrays.stream(input.split(","))
+                .filter(metadataKeyValue -> !metadataKeyValue.trim().isEmpty())
+                .map(metadataKeyValue -> metadataKeyValue.split(":", 2))
+                .forEach(keyValue -> {
+                    if (keyValue.length != 2) {
+                        throw new IllegalArgumentException(String.format("provided metadata %s is invalid", input));
+                    }
+                    metadata.put(Metadata.Key.of(keyValue[0].trim(), Metadata.ASCII_STRING_MARSHALLER), keyValue[1].trim());
+                });
 
-        Arrays.stream(input.split(",")).filter(metadataKeyValue -> !metadataKeyValue.trim().isEmpty()).forEach(metadataKeyValue -> {
-            if (metadataKeyValue.contains(":")) {
-                metadata.put(Metadata.Key.of(metadataKeyValue.split(":")[0], Metadata.ASCII_STRING_MARSHALLER), metadataKeyValue.split(":")[1]);
-            }
-        });
         return metadata;
     }
 }

--- a/src/main/java/com/gotocompany/firehose/sink/grpc/client/GrpcClient.java
+++ b/src/main/java/com/gotocompany/firehose/sink/grpc/client/GrpcClient.java
@@ -68,10 +68,12 @@ public class GrpcClient {
             return stencilClient.parse(grpcSinkConfig.getSinkGrpcResponseSchemaProtoClass(), response);
 
         } catch (StatusRuntimeException sre) {
-            firehoseInstrumentation.logError("GRPC call failed with metadata: {}, error message: {}", metadata.toString(), sre.getMessage());
+            firehoseInstrumentation.logError("GRPC call failed with error message: {}", sre.getMessage());
+            firehoseInstrumentation.logDebug("GRPC call metadata: {}", metadata.toString());
             firehoseInstrumentation.incrementCounter(Metrics.SINK_GRPC_ERROR_TOTAL,  "status=" + sre.getStatus().getCode());
         } catch (Exception e) {
-            firehoseInstrumentation.logError("GRPC call failed with metadata: {}, error message: {}", metadata.toString(), e.getMessage());
+            firehoseInstrumentation.logError("GRPC call failed with error message: {}", e.getMessage());
+            firehoseInstrumentation.logDebug("GRPC call metadata: {}", metadata.toString());
             firehoseInstrumentation.incrementCounter(Metrics.SINK_GRPC_ERROR_TOTAL, "status=UNIDENTIFIED");
         }
         return emptyResponse;

--- a/src/main/java/com/gotocompany/firehose/sink/grpc/client/GrpcClient.java
+++ b/src/main/java/com/gotocompany/firehose/sink/grpc/client/GrpcClient.java
@@ -38,6 +38,7 @@ public class GrpcClient {
     private ManagedChannel managedChannel;
     private final MethodDescriptor<byte[], byte[]> methodDescriptor;
     private final DynamicMessage emptyResponse;
+    private final Metadata grpcAdditionalMetadata;
 
     public GrpcClient(FirehoseInstrumentation firehoseInstrumentation, GrpcSinkConfig grpcSinkConfig, ManagedChannel managedChannel, StencilClient stencilClient) {
         this.firehoseInstrumentation = firehoseInstrumentation;
@@ -50,15 +51,12 @@ public class GrpcClient {
                 .setFullMethodName(grpcSinkConfig.getSinkGrpcMethodUrl())
                 .build();
         this.emptyResponse = DynamicMessage.newBuilder(this.stencilClient.get(this.grpcSinkConfig.getSinkGrpcResponseSchemaProtoClass())).build();
+        this.grpcAdditionalMetadata = grpcSinkConfig.getSinkGrpcMetadata();
     }
 
     public DynamicMessage execute(byte[] logMessage, Headers headers) {
-
+        Metadata metadata = buildMetadata(headers);
         try {
-            Metadata metadata = new Metadata();
-            for (Header header : headers) {
-                metadata.put(Metadata.Key.of(header.key(), Metadata.ASCII_STRING_MARSHALLER), new String(header.value()));
-            }
             Channel decoratedChannel = ClientInterceptors.intercept(managedChannel,
                      MetadataUtils.newAttachHeadersInterceptor(metadata));
             byte[] response = ClientCalls.blockingUnaryCall(
@@ -70,13 +68,22 @@ public class GrpcClient {
             return stencilClient.parse(grpcSinkConfig.getSinkGrpcResponseSchemaProtoClass(), response);
 
         } catch (StatusRuntimeException sre) {
-            firehoseInstrumentation.logWarn(sre.getMessage());
+            firehoseInstrumentation.logError("GRPC call failed with metadata: {}, error message: {}", metadata.toString(), sre.getMessage());
             firehoseInstrumentation.incrementCounter(Metrics.SINK_GRPC_ERROR_TOTAL,  "status=" + sre.getStatus().getCode());
         } catch (Exception e) {
-            firehoseInstrumentation.logWarn(e.getMessage());
+            firehoseInstrumentation.logError("GRPC call failed with metadata: {}, error message: {}", metadata.toString(), e.getMessage());
             firehoseInstrumentation.incrementCounter(Metrics.SINK_GRPC_ERROR_TOTAL, "status=UNIDENTIFIED");
         }
         return emptyResponse;
+    }
+
+    protected Metadata buildMetadata(Headers headers) {
+        Metadata metadata = new Metadata();
+        for (Header header : headers) {
+            metadata.put(Metadata.Key.of(header.key(), Metadata.ASCII_STRING_MARSHALLER), new String(header.value()));
+        }
+        metadata.merge(grpcAdditionalMetadata);
+        return metadata;
     }
 
     protected CallOptions decoratedDefaultCallOptions() {

--- a/src/main/java/com/gotocompany/firehose/sink/grpc/client/GrpcClient.java
+++ b/src/main/java/com/gotocompany/firehose/sink/grpc/client/GrpcClient.java
@@ -38,7 +38,7 @@ public class GrpcClient {
     private ManagedChannel managedChannel;
     private final MethodDescriptor<byte[], byte[]> methodDescriptor;
     private final DynamicMessage emptyResponse;
-    private final Metadata grpcAdditionalMetadata;
+    private final Metadata grpcStaticMetadata;
 
     public GrpcClient(FirehoseInstrumentation firehoseInstrumentation, GrpcSinkConfig grpcSinkConfig, ManagedChannel managedChannel, StencilClient stencilClient) {
         this.firehoseInstrumentation = firehoseInstrumentation;
@@ -51,7 +51,7 @@ public class GrpcClient {
                 .setFullMethodName(grpcSinkConfig.getSinkGrpcMethodUrl())
                 .build();
         this.emptyResponse = DynamicMessage.newBuilder(this.stencilClient.get(this.grpcSinkConfig.getSinkGrpcResponseSchemaProtoClass())).build();
-        this.grpcAdditionalMetadata = grpcSinkConfig.getSinkGrpcMetadata();
+        this.grpcStaticMetadata = grpcSinkConfig.getSinkGrpcMetadata();
     }
 
     public DynamicMessage execute(byte[] logMessage, Headers headers) {
@@ -83,7 +83,7 @@ public class GrpcClient {
         for (Header header : headers) {
             metadata.put(Metadata.Key.of(header.key(), Metadata.ASCII_STRING_MARSHALLER), new String(header.value()));
         }
-        metadata.merge(grpcAdditionalMetadata);
+        metadata.merge(grpcStaticMetadata);
         return metadata;
     }
 

--- a/src/test/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverterTest.java
+++ b/src/test/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverterTest.java
@@ -1,0 +1,19 @@
+package com.gotocompany.firehose.config.converter;
+
+import io.grpc.Metadata;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class GrpcMetadataConverterTest {
+
+    @Test
+    public void shouldConvertConfigToMetadata() {
+        Metadata actualMetadata = new GrpcMetadataConverter().convert(null, "k1:v1,k2:v2,k3:v3");
+        assertEquals(Arrays.asList("k1", "k2", "k3").stream().collect(Collectors.toSet()), actualMetadata.keys());
+    }
+}

--- a/src/test/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverterTest.java
+++ b/src/test/java/com/gotocompany/firehose/config/converter/GrpcMetadataConverterTest.java
@@ -13,7 +13,13 @@ public class GrpcMetadataConverterTest {
 
     @Test
     public void shouldConvertConfigToMetadata() {
-        Metadata actualMetadata = new GrpcMetadataConverter().convert(null, "k1:v1,k2:v2,k3:v3");
+        Metadata actualMetadata = new GrpcMetadataConverter().convert(null, "k1:v1,k2:v2, k3:v3");
         assertEquals(Arrays.asList("k1", "k2", "k3").stream().collect(Collectors.toSet()), actualMetadata.keys());
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowOnIllegalArgument() {
+        new GrpcMetadataConverter().convert(null, "k1:v1,k2:v2,k3:v3,k4");
     }
 }

--- a/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
@@ -24,11 +24,8 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Stubber;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -132,6 +129,28 @@ public class GrpcClientTest {
         grpcClient.execute(request.toByteArray(), headers);
 
         assertEquals(headerTestInterceptor.getKeyValues(), Arrays.asList(headerValue1, headerValue2));
+    }
+
+    @Test
+    public void shouldBuildConsolidatedMetadataFromHeaderAndStaticMetadata() {
+        Map<String, String> config = new HashMap<>();
+        config.put("SINK_GRPC_SERVICE_HOST", "localhost");
+        config.put("SINK_GRPC_SERVICE_PORT", "5000");
+        config.put("SINK_GRPC_METHOD_URL", "com.gotocompany.firehose.consumer.TestServer/TestRpcMethod");
+        config.put("SINK_GRPC_RESPONSE_SCHEMA_PROTO_CLASS", "com.gotocompany.firehose.consumer.TestGrpcResponse");
+        config.put("SINK_GRPC_METADATA", "token:123,dlq:true");
+        GrpcSinkConfig grpcSinkConfig = ConfigFactory.create(GrpcSinkConfig.class, config);
+        StencilClient stencilClient = StencilClientFactory.getClient();
+        ManagedChannel managedChannel = ManagedChannelBuilder.forAddress(grpcSinkConfig.getSinkGrpcServiceHost(), grpcSinkConfig.getSinkGrpcServicePort()).usePlaintext().build();
+        grpcClient = new GrpcClient(firehoseInstrumentation, grpcSinkConfig, managedChannel, stencilClient);
+        String headerValue1 = "test-value-1";
+        String headerValue2 = "test-value-2";
+        headers.add(new RecordHeader(HEADER_KEYS.get(0), headerValue1.getBytes()));
+        headers.add(new RecordHeader(HEADER_KEYS.get(1), headerValue2.getBytes()));
+
+        Metadata resultMetadata = grpcClient.buildMetadata(headers);
+
+        assertEquals(Arrays.asList("dlq", "test-header-key-1", "test-header-key-2", "token").stream().collect(Collectors.toSet()), resultMetadata.keys());
     }
 
     @Test

--- a/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
+++ b/src/test/java/com/gotocompany/firehose/sink/grpc/client/GrpcClientTest.java
@@ -138,7 +138,7 @@ public class GrpcClientTest {
         config.put("SINK_GRPC_SERVICE_PORT", "5000");
         config.put("SINK_GRPC_METHOD_URL", "com.gotocompany.firehose.consumer.TestServer/TestRpcMethod");
         config.put("SINK_GRPC_RESPONSE_SCHEMA_PROTO_CLASS", "com.gotocompany.firehose.consumer.TestGrpcResponse");
-        config.put("SINK_GRPC_METADATA", "token:123,dlq:true");
+        config.put("SINK_GRPC_METADATA", " ,token: 123, dlq:true,");
         GrpcSinkConfig grpcSinkConfig = ConfigFactory.create(GrpcSinkConfig.class, config);
         StencilClient stencilClient = StencilClientFactory.getClient();
         ManagedChannel managedChannel = ManagedChannelBuilder.forAddress(grpcSinkConfig.getSinkGrpcServiceHost(), grpcSinkConfig.getSinkGrpcServicePort()).usePlaintext().build();
@@ -151,6 +151,11 @@ public class GrpcClientTest {
         Metadata resultMetadata = grpcClient.buildMetadata(headers);
 
         assertEquals(Arrays.asList("dlq", "test-header-key-1", "test-header-key-2", "token").stream().collect(Collectors.toSet()), resultMetadata.keys());
+
+        assertEquals("true", resultMetadata.get(Metadata.Key.of("dlq", Metadata.ASCII_STRING_MARSHALLER)));
+        assertEquals("test-value-1", resultMetadata.get(Metadata.Key.of("test-header-key-1", Metadata.ASCII_STRING_MARSHALLER)));
+        assertEquals("test-value-2", resultMetadata.get(Metadata.Key.of("test-header-key-2", Metadata.ASCII_STRING_MARSHALLER)));
+        assertEquals("123", resultMetadata.get(Metadata.Key.of("token", Metadata.ASCII_STRING_MARSHALLER)));
     }
 
     @Test


### PR DESCRIPTION
Enhancing functionality to allow configuration of static metadata in gRPC calls, in addition to Kafka message headers.
