### PR TITLE
fix: fixing curl security vulnerability issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY ./ ./
 RUN ./gradlew build
 
 FROM openjdk:8-jre
-RUN apt-get update && apt-get upgrade curl
+RUN apt-get update && apt-get upgrade -y curl
 COPY --from=GRADLE_BUILD ./build/libs/ /opt/firehose/bin
 COPY --from=GRADLE_BUILD ./jolokia-jvm-agent.jar /opt/firehose
 COPY --from=GRADLE_BUILD ./src/main/resources/log4j.xml /opt/firehose/etc/log4j.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY ./ ./
 RUN ./gradlew build
 
 FROM openjdk:8-jre
+RUN apt-get update && apt-get upgrade curl
 COPY --from=GRADLE_BUILD ./build/libs/ /opt/firehose/bin
 COPY --from=GRADLE_BUILD ./jolokia-jvm-agent.jar /opt/firehose
 COPY --from=GRADLE_BUILD ./src/main/resources/log4j.xml /opt/firehose/etc/log4j.xml

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ lombok {
 }
 
 group 'com.gotocompany'
-version '0.9.9'
+version '0.9.10'
 
 def projName = "firehose"
 


### PR DESCRIPTION
This merge request addresses a critical Heap Buffer Overflow vulnerability in cURL and libcurl (CVE-2023-38545). 

The fix for this vulnerability is included in the Debian version 7.74.0-1.3+deb11u11 [here](https://security-tracker.debian.org/tracker/source-package/curl). For more detailed information regarding the changes and affected packages in this Debian fix version, please refer to the provided [changelog](https://metadata.ftp-master.debian.org/changelogs//main/c/curl/curl_7.74.0-1.3+deb11u11_changelog).