### PR TITLE
Firehose JRE upgrade to jre8u412

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN curl -L http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-j
 COPY ./ ./
 RUN ./gradlew build
 
-FROM openjdk:8-jre
+FROM eclipse-temurin:8u412-b08-jre
 RUN apt-get update && apt-get upgrade -y curl
 COPY --from=GRADLE_BUILD ./build/libs/ /opt/firehose/bin
 COPY --from=GRADLE_BUILD ./jolokia-jvm-agent.jar /opt/firehose

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ lombok {
 }
 
 group 'com.gotocompany'
-version '0.10.1'
+version '0.10.2'
 
 def projName = "firehose"
 


### PR DESCRIPTION
**Context:**
The current image which is being used in the firehose is https://hub.docker.com/layers/library/openjdk/8-jre/images/sha256-a6a74c7b774e00fd2ec5664e257d344f1b7e69e2a618b1c0678f69719863c5ad which is using 8u342 jre.

**Problem Statement:**
As mentioned in the Kubernetes docs, if the container deployment has to be aware of cgroup v2, we should use jre8u372 or later. https://kubernetes.io/docs/concepts/architecture/cgroups/#migrating-cgroupv2 https://bugs.openjdk.org/browse/JDK-8230305

**Analysis:**
OpenJDK HomePage https://hub.docker.com/_/openjdk mentions that these images are for Pre-release / non-production builds. This image is officially deprecated and all users are recommended to find and use suitable replacements ASAP. More Details here: https://github.com/docker-library/openjdk/issues/505 Even adoptOpenJDK images are deprecated https://hub.docker.com/_/adoptopenjdk and they recommend to use below trusted community jre/jdk builds

eclipse-temurin: is one of the recommended jre Trusted Community - eclipse-temurin:8u412-b08-jre This is also used in flink/dagger image
https://hub.docker.com/layers/library/eclipse-temurin/8u412-b08-jre/images/sha256-4862d0a70086408ddb5267a5c1d83a8d4d2656095d71ab4318b178f38fe1321e?context=explore

Amazon Corretto - some users have complained about the memory management issues https://www.g2.com/products/amazon-corretto/reviews#survey-response-9386019

**Solution:**
Since we are using the Eclipse Temurin JDK release in Dagger and the Flink community is also using it, we have decided to do the same.

**Test Results:**
We have used a high throughput input stream for this test and used log sink and we have used test docker Image used - https://hub.docker.com/r/rajugt/raju-firehose-java-jdk8u412/tags

**We just changed the pod container image for the test firehose around 16:45**

<img width="663" alt="image" src="https://github.com/goto/firehose/assets/2203863/9f629f13-8203-433a-9217-86861244d8c1">

<img width="670" alt="image" src="https://github.com/goto/firehose/assets/2203863/a3d47185-3480-4624-a6f9-2ae0ddf18f50">

<img width="660" alt="image" src="https://github.com/goto/firehose/assets/2203863/d604f5ee-0a58-41fe-9057-3a72a9e0d2c0">

<img width="672" alt="image" src="https://github.com/goto/firehose/assets/2203863/0a10b85b-e776-4e3d-a0e5-6b9aa29e52c3">

<img width="662" alt="image" src="https://github.com/goto/firehose/assets/2203863/01c9f9c2-8534-4ba4-ba54-70e205ebb50f">

<img width="660" alt="image" src="https://github.com/goto/firehose/assets/2203863/57913944-9989-4fce-b052-8ad1756d5b10">
<br/><br/><br/><br/>

**Observation: CPU throttling got reduced significantly on an avg 8% to >0.1%**

<br/><br/>
<img width="664" alt="image" src="https://github.com/goto/firehose/assets/2203863/587e62f7-1cf3-4f75-9a1b-d02b51d05ebe">

<img width="660" alt="image" src="https://github.com/goto/firehose/assets/2203863/b9486f59-4a60-405a-a377-20f3b7301e32">

<br/><br/>

**Observation: Container memory got reduced >10%**

<br/><br/>

<img width="602" alt="image" src="https://github.com/goto/firehose/assets/2203863/ae56b3f8-ab22-481e-9a68-84635902cbbe">

<img width="376" alt="image" src="https://github.com/goto/firehose/assets/2203863/83755b9a-bf7e-42e2-aa14-4e4001092703">

<img width="634" alt="image" src="https://github.com/goto/firehose/assets/2203863/e30af187-28c7-4af8-89ec-57fc1bd0b1ef">

<img width="1293" alt="image" src="https://github.com/goto/firehose/assets/2203863/0dc8ee1f-7b27-4928-94a0-465546f8e644">


<br/><br/>

**Observation: firehose able to process from ~4M to ~5Million messages (there is no change in input throughput)**

<br/><br/>

**Memory & GC metrics**

<img width="1289" alt="image" src="https://github.com/goto/firehose/assets/2203863/52f53e56-5be9-4cbb-bef5-921ddd6909b0">

<img width="1293" alt="image" src="https://github.com/goto/firehose/assets/2203863/d195eda6-a431-46db-90af-007e060b3710">

**Observation: GC count and time has reduced** 

<img width="1293" alt="image" src="https://github.com/goto/firehose/assets/2203863/e7314552-2ed7-47fa-aeca-376f5e08498b">
