### PR TITLE
chore: Bump depot to 0.10.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ lombok {
 }
 
 group 'com.gotocompany'
-version '0.12.2'
+version '0.12.3'
 
 def projName = "firehose"
 
@@ -101,7 +101,7 @@ dependencies {
     implementation 'com.google.cloud:google-cloud-storage:2.20.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
     implementation group: 'com.aliyun.oss', name: 'aliyun-sdk-oss', version: '3.18.1'
-    implementation group: 'com.gotocompany', name: 'depot', version: '0.10.8'
+    implementation group: 'com.gotocompany', name: 'depot', version: '0.10.9'
     implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.59' exclude group: 'org.slf4j'
     implementation 'dev.cel:cel:0.5.2'
     implementation 'com.qcloud:cos_api:5.6.227'


### PR DESCRIPTION
Bump depot to 0.10.9

Fixes : 
- Limit on MC nested message depth
- Bugfix on MC default value 