### PR TITLE
[phase-4] Add KAFKA sink type to Firehose

### DIFF
--- a/src/main/java/com/gotocompany/firehose/config/enums/SinkType.java
+++ b/src/main/java/com/gotocompany/firehose/config/enums/SinkType.java
@@ -20,5 +20,6 @@ public enum SinkType {
     BIGQUERY,
     BIGTABLE,
     MONGODB,
-    MAXCOMPUTE
+    MAXCOMPUTE,
+    KAFKA
 }

--- a/src/main/java/com/gotocompany/firehose/sink/SinkFactory.java
+++ b/src/main/java/com/gotocompany/firehose/sink/SinkFactory.java
@@ -7,8 +7,11 @@ import com.gotocompany.depot.bigtable.BigTableSinkFactory;
 import com.gotocompany.depot.config.BigQuerySinkConfig;
 import com.gotocompany.depot.config.BigTableSinkConfig;
 import com.gotocompany.depot.config.HttpSinkConfig;
+import com.gotocompany.depot.config.KafkaSinkConfig;
 import com.gotocompany.depot.config.RedisSinkConfig;
 import com.gotocompany.depot.http.HttpSink;
+import com.gotocompany.depot.kafka.KafkaSink;
+import com.gotocompany.depot.kafka.KafkaSinkFactory;
 import com.gotocompany.depot.log.LogSink;
 import com.gotocompany.depot.log.LogSinkFactory;
 import com.gotocompany.depot.maxcompute.MaxComputeSink;
@@ -49,6 +52,7 @@ public class SinkFactory {
     private RedisSinkFactory redisSinkFactory;
     private com.gotocompany.depot.http.HttpSinkFactory httpv2SinkFactory;
     private MaxComputeSinkFactory maxComputeSinkFactory;
+    private KafkaSinkFactory kafkaSinkFactory;
 
     public SinkFactory(KafkaConsumerConfig kafkaConsumerConfig,
                        StatsDReporter statsDReporter,
@@ -111,6 +115,13 @@ public class SinkFactory {
                 maxComputeSinkFactory = new MaxComputeSinkFactory(statsDReporter, stencilClient, config);
                 maxComputeSinkFactory.init();
                 return;
+            case KAFKA:
+                kafkaSinkFactory = new KafkaSinkFactory(
+                        ConfigFactory.create(KafkaSinkConfig.class, config),
+                        statsDReporter,
+                        config);
+                kafkaSinkFactory.init();
+                return;
             default:
                 throw new ConfigurationException("Invalid Firehose SINK_TYPE");
         }
@@ -148,6 +159,8 @@ public class SinkFactory {
                 return new GenericSink(new FirehoseInstrumentation(statsDReporter, HttpSink.class), sinkType.name(), httpv2SinkFactory.create());
             case MAXCOMPUTE:
                 return new GenericSink(new FirehoseInstrumentation(statsDReporter, MaxComputeSink.class), sinkType.name(), maxComputeSinkFactory.create());
+            case KAFKA:
+                return new GenericSink(new FirehoseInstrumentation(statsDReporter, KafkaSink.class), sinkType.name(), kafkaSinkFactory.create());
             default:
                 throw new ConfigurationException("Invalid Firehose SINK_TYPE");
         }


### PR DESCRIPTION
- Add KAFKA to SinkType enum
- Register KafkaSinkFactory in SinkFactory.init() and getSink()
- Uses GenericSink wrapper (same pattern as Redis, BigQuery, BigTable, MaxCompute)
- Passes config map to KafkaSinkFactory for SINK_KAFKA_* passthrough configs
- Requires depot with kafka package (local or published)
