### PR TITLE
feat(firehose): register KAFKA sink type

### DIFF
--- a/src/main/java/com/gotocompany/firehose/config/enums/SinkType.java
+++ b/src/main/java/com/gotocompany/firehose/config/enums/SinkType.java
@@ -20,5 +20,6 @@ public enum SinkType {
     BIGQUERY,
     BIGTABLE,
     MONGODB,
-    MAXCOMPUTE
+    MAXCOMPUTE,
+    KAFKA
 }

--- a/src/main/java/com/gotocompany/firehose/sink/SinkFactory.java
+++ b/src/main/java/com/gotocompany/firehose/sink/SinkFactory.java
@@ -9,6 +9,9 @@ import com.gotocompany.depot.config.BigTableSinkConfig;
 import com.gotocompany.depot.config.HttpSinkConfig;
 import com.gotocompany.depot.config.RedisSinkConfig;
 import com.gotocompany.depot.http.HttpSink;
+import com.gotocompany.depot.kafka.KafkaSink;
+import com.gotocompany.depot.kafka.KafkaSinkConfig;
+import com.gotocompany.depot.kafka.KafkaSinkFactory;
 import com.gotocompany.depot.log.LogSink;
 import com.gotocompany.depot.log.LogSinkFactory;
 import com.gotocompany.depot.maxcompute.MaxComputeSink;
@@ -49,6 +52,7 @@ public class SinkFactory {
     private RedisSinkFactory redisSinkFactory;
     private com.gotocompany.depot.http.HttpSinkFactory httpv2SinkFactory;
     private MaxComputeSinkFactory maxComputeSinkFactory;
+    private KafkaSinkFactory kafkaSinkFactory;
 
     public SinkFactory(KafkaConsumerConfig kafkaConsumerConfig,
                        StatsDReporter statsDReporter,
@@ -111,6 +115,13 @@ public class SinkFactory {
                 maxComputeSinkFactory = new MaxComputeSinkFactory(statsDReporter, stencilClient, config);
                 maxComputeSinkFactory.init();
                 return;
+            case KAFKA:
+                kafkaSinkFactory = new KafkaSinkFactory(
+                        ConfigFactory.create(KafkaSinkConfig.class, config),
+                        statsDReporter,
+                        config);
+                kafkaSinkFactory.init();
+                return;
             default:
                 throw new ConfigurationException("Invalid Firehose SINK_TYPE");
         }
@@ -148,6 +159,8 @@ public class SinkFactory {
                 return new GenericSink(new FirehoseInstrumentation(statsDReporter, HttpSink.class), sinkType.name(), httpv2SinkFactory.create());
             case MAXCOMPUTE:
                 return new GenericSink(new FirehoseInstrumentation(statsDReporter, MaxComputeSink.class), sinkType.name(), maxComputeSinkFactory.create());
+            case KAFKA:
+                return new GenericSink(new FirehoseInstrumentation(statsDReporter, KafkaSink.class), sinkType.name(), kafkaSinkFactory.create());
             default:
                 throw new ConfigurationException("Invalid Firehose SINK_TYPE");
         }


### PR DESCRIPTION
Adds KAFKA to the SinkType enum and wires KafkaSinkFactory from depot into SinkFactory.init() and SinkFactory.getSink(), following the same pattern as existing sink types (REDIS, BIGTABLE, MAXCOMPUTE).

## Hey, I just made a Pull Request!
Please describe what you added, and add a screenshot if possible.
That makes it easier to understand the change so we can :shipit: faster.

#### :heavy_check_mark: Checklist
<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changelog describing the changes and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)